### PR TITLE
WDL improvements

### DIFF
--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -196,7 +196,7 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     print("Booting up sfkit-proxy")
     doc_ref_dict: dict = get_doc_ref_dict()
     study_id: str = doc_ref_dict["study_id"]
-    config_file_path = f"{constants.EXECUTABLES_PREFIX}sfgwas/config/{protocol}/configGlobal.toml" 
+    config_file_path = f"{constants.EXECUTABLES_PREFIX}sfgwas/config/{protocol}/configGlobal.toml"
     with open(constants.AUTH_KEY, "r") as f:
         auth_key = f.readline().rstrip()
     api_url = os.getenv("SFKIT_API_URL", "").replace("https", "wss") + "/ice"
@@ -222,7 +222,7 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     print(f"Running command: {command}")
     p = subprocess.Popen(command)
 
-    # send SIGTERM on skfit CLI exit
+    # send SIGTERM on sfkit CLI exit
     atexit.register(p.terminate)
 
     # 1 sec delay before we start the MPC protocol,

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -14,7 +14,8 @@ workflow sfkit {
       study_id = study_id,
       num_threads = num_threads,
       num_parties = num_parties,
-      api_url = api_url
+      api_url = api_url,
+      data = data,
   }
 }
 
@@ -24,6 +25,7 @@ task cli {
     Int num_threads
     Int num_parties
     String api_url
+    Directory? data
   }
 
   command <<<
@@ -42,8 +44,11 @@ task cli {
       sfkit networking --ports "$(<ports.txt)"
       sfkit generate_keys
 
-      # NOTE: we can't set sysctl in WDL environment, so just leave it alone;
-      # also, the data disk is mounted at /cromwell_root, in case it's needed.
+      if [ -n "~{data}" ]; then
+        sfkit register_data --data_path "~{data}"
+      fi
+
+      # NOTE: we can't set sysctl in WDL environment, so just leave it alone
       sfkit run_protocol
   >>>
 

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -6,6 +6,7 @@ workflow sfkit {
     Directory? data
     Int num_threads = 2
     String api_url = "https://sfkit.dsde.broadinstitute.org/api"
+    String docker = "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit"
   }
 
   call cli {
@@ -14,6 +15,7 @@ workflow sfkit {
       data = data,
       num_threads = num_threads,
       api_url = api_url,
+      docker = docker,
   }
 }
 
@@ -23,6 +25,7 @@ task cli {
     Directory? data
     Int num_threads
     String api_url
+    String docker
   }
 
   command <<<
@@ -45,7 +48,7 @@ task cli {
   >>>
 
   runtime {
-    docker: "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit:v0.0.46-59ff010"
+    docker: docker
     cpu: num_threads
     memory: "~{num_threads * 8} GB"
   }

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -6,7 +6,7 @@ workflow sfkit {
     Int num_threads = 2
     Int num_parties = 2
     String api_url = "https://sfkit.dsde.broadinstitute.org/api"
-    Directory data
+    Directory? data
   }
 
   call cli {

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -48,17 +48,16 @@ task cli {
         sfkit register_data --data_path "~{data}"
       fi
 
-      # NOTE: we can't set sysctl in WDL environment, so just leave it alone
       sfkit run_protocol
   >>>
-
-  output {
-    String out = read_string(stdout())
-  }
 
   runtime {
     docker: "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit"
     cpu: num_threads
     memory: "~{num_threads * 8} GB"
+  }
+
+  output {
+    String out = read_string(stdout())
   }
 }

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -45,7 +45,7 @@ task cli {
   >>>
 
   runtime {
-    docker: "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit"
+    docker: "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit:v0.0.46-59ff010"
     cpu: num_threads
     memory: "~{num_threads * 8} GB"
   }

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -4,7 +4,6 @@ workflow sfkit {
   input {
     String study_id
     Int num_threads = 2
-    Int num_parties = 2
     String api_url = "https://sfkit.dsde.broadinstitute.org/api"
     Directory? data
   }
@@ -13,7 +12,6 @@ workflow sfkit {
     input:
       study_id = study_id,
       num_threads = num_threads,
-      num_parties = num_parties,
       api_url = api_url,
       data = data,
   }
@@ -23,7 +21,6 @@ task cli {
   input {
     String study_id
     Int num_threads
-    Int num_parties
     String api_url
     Directory? data
   }

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -48,6 +48,11 @@ task cli {
         sfkit register_data --data_path "~{data}"
       fi
 
+      python <<CODE
+      import os
+      print(os.environ)
+      CODE
+
       sfkit run_protocol
   >>>
 

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -32,7 +32,7 @@ task cli {
       set -xeu
 
       export PYTHONUNBUFFERED=TRUE
-      export SKFIT_PROXY_ON=true
+      export SFKIT_PROXY_ON=true
       export SFKIT_API_URL="~{api_url}"
       cd /sfkit
 
@@ -47,11 +47,6 @@ task cli {
       if [ -n "~{data}" ]; then
         sfkit register_data --data_path "~{data}"
       fi
-
-      python <<CODE
-      import os
-      print(os.environ)
-      CODE
 
       sfkit run_protocol
   >>>

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -3,26 +3,26 @@ version development
 workflow sfkit {
   input {
     String study_id
+    Directory? data
     Int num_threads = 2
     String api_url = "https://sfkit.dsde.broadinstitute.org/api"
-    Directory? data
   }
 
   call cli {
     input:
       study_id = study_id,
+      data = data,
       num_threads = num_threads,
       api_url = api_url,
-      data = data,
   }
 }
 
 task cli {
   input {
     String study_id
+    Directory? data
     Int num_threads
     String api_url
-    Directory? data
   }
 
   command <<<

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -4,7 +4,7 @@ workflow sfkit {
   input {
     String study_id
     Directory? data
-    Int num_threads = 2
+    Int num_cores = 2
     String api_url = "https://sfkit.dsde.broadinstitute.org/api"
     String docker = "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit"
   }
@@ -13,7 +13,7 @@ workflow sfkit {
     input:
       study_id = study_id,
       data = data,
-      num_threads = num_threads,
+      num_cores = num_cores,
       api_url = api_url,
       docker = docker,
   }
@@ -23,7 +23,7 @@ task cli {
   input {
     String study_id
     Directory? data
-    Int num_threads
+    Int num_cores
     String api_url
     String docker
   }
@@ -49,8 +49,8 @@ task cli {
 
   runtime {
     docker: docker
-    cpu: num_threads
-    memory: "~{num_threads * 8} GB"
+    cpu: num_cores
+    memory: "~{num_cores * 8} GB"
   }
 
   output {

--- a/workflow.wdl
+++ b/workflow.wdl
@@ -36,12 +36,8 @@ task cli {
       export SFKIT_API_URL="~{api_url}"
       cd /sfkit
 
-      python >ports.txt <<CODE
-      print(','.join([str(8100 + ~{num_threads} * p) for p in range(~{num_parties})]))
-      CODE
-
       sfkit auth --study_id "~{study_id}"
-      sfkit networking --ports "$(<ports.txt)"
+      sfkit networking
       sfkit generate_keys
 
       if [ -n "~{data}" ]; then


### PR DESCRIPTION
* Passes `study_id` to `sfkit auth`
* Auto-configures ports
* Does away with `pid`, which is inferred automatically by sfkit CLI
* Passes optional data `Directory` input to `sfkit register_data`
* Adds configurable `num_cores` and `docker` URL
* Fixes typo in `SFKIT_PROXY_ON