### PR TITLE
Rebuild sfkit-proxy and fix ws URL for http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -s /usr/bin/python python3
 FROM go AS sfkit-proxy
 
 # compile Go code
-RUN git clone https://github.com/hcholab/sfkit-proxy . && \
+RUN git clone --depth 1 https://github.com/hcholab/sfkit-proxy . && \
     # use static compilation
     CGO_ENABLED=0 go build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,8 @@ RUN ln -s /usr/bin/python python3
 
 
 FROM go AS sfkit-proxy
-
-# compile Go code
-RUN git clone --depth 1 https://github.com/hcholab/sfkit-proxy . && \
-    # use static compilation
+RUN git clone https://github.com/hcholab/sfkit-proxy . && \
+    git checkout a422951 && \
     CGO_ENABLED=0 go build
 
 
@@ -108,7 +106,7 @@ ENV PATH="$PATH:/sfkit:/sfkit/sfgwas:/sfkit/sf-relate:/home/nonroot/.local/bin:/
     SFKIT_DIR="/sfkit/.sfkit" \
     GOPATH="/tmp/go" \
     GOROOT="/usr/local/go" \
-    GOPROXY="https://proxy.golang.org" 
+    GOPROXY="https://proxy.golang.org"
 
 # hadolint ignore=DL3022
 COPY --from=dev /usr/bin/wget /usr/bin/wget

--- a/sfkit/auth/setup_networking.py
+++ b/sfkit/auth/setup_networking.py
@@ -42,7 +42,7 @@ def setup_networking(ports_str: str, ip_address: str = "") -> None:
     else:
         # auto-calculate port assignment
         role = str(doc_ref_dict["participants"].index(get_username()))
-        base = 8000 + MAX_PARTICIPANTS * MAX_THREADS * int(role)
+        base = 8100 + MAX_PARTICIPANTS * MAX_THREADS * int(role)
         ports = [base + MAX_THREADS * r for r in range(len(doc_ref_dict["participants"]))]
         ports_str = ",".join([str(p) for p in ports])
 

--- a/sfkit/protocol/run_protocol.py
+++ b/sfkit/protocol/run_protocol.py
@@ -38,6 +38,7 @@ def run_protocol(
     ):
         statuses[username] = "ready to begin protocol"
         update_firestore("update_firestore::status=ready to begin protocol")
+
     if statuses[username] == "ready to begin protocol":
         while not demo and other_participant_not_ready(list(statuses.values())):
             print("Other participant(s) not yet ready.  Waiting... (press CTRL-C to cancel)")

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -200,7 +200,8 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
 
     url = urlparse(constants.SFKIT_API_URL)
     scheme = "wss" if url.scheme == "https" else "ws"
-    api_url = urlunsplit((scheme, str(url.netloc), os.path.join(url.path, "ice"), "", ""))
+    url_path = os.path.join(url.path, "ice")
+    api_url = urlunsplit((scheme, str(url.netloc), url_path, "", ""))
 
     # do not use shell, as this may lead to security
     # vulnerabilities and improper signal handling;

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 from time import sleep
 from typing import Tuple, Union
-from urllib.parse import urljoin, urlparse, urlunsplit
+from urllib.parse import urlparse, urlunsplit
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -200,7 +200,7 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
 
     url = urlparse(constants.SFKIT_API_URL)
     scheme = "wss" if url.scheme == "https" else "ws"
-    url_path = urljoin(url.path, 'ice')
+    url_path = os.path.join(url.path, "ice")
     api_url = urlunsplit((scheme, str(url.netloc), url_path, "", ""))
 
     # do not use shell, as this may lead to security

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -232,4 +232,5 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     # in practice, this happens much quicker within ~100ms
     sleep(1)
 
+
     print("sfkit-proxy is running")

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -200,8 +200,7 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
 
     url = urlparse(constants.SFKIT_API_URL)
     scheme = "wss" if url.scheme == "https" else "ws"
-    url_path = os.path.join(url.path, "ice")
-    api_url = urlunsplit((scheme, str(url.netloc), url_path, "", ""))
+    api_url = urlunsplit((scheme, str(url.netloc), os.path.join(url.path, "ice"), "", ""))
 
     # do not use shell, as this may lead to security
     # vulnerabilities and improper signal handling;

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -5,19 +5,17 @@ import shutil
 import subprocess
 from time import sleep
 from typing import Tuple, Union
+from urllib.parse import urljoin, urlparse, urlunsplit
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from sfkit.api import get_doc_ref_dict, update_firestore, website_send_file
 from sfkit.utils import constants
-from sfkit.utils.helper_functions import (
-    condition_or_fail,
-    copy_results_to_cloud_storage,
-    copy_to_out_folder,
-    plot_assoc,
-    postprocess_assoc,
-)
+from sfkit.utils.helper_functions import (condition_or_fail,
+                                          copy_results_to_cloud_storage,
+                                          copy_to_out_folder, plot_assoc,
+                                          postprocess_assoc)
 
 
 def get_file_paths() -> Tuple[str, str]:
@@ -199,7 +197,11 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     config_file_path = f"{constants.EXECUTABLES_PREFIX}sfgwas/config/{protocol}/configGlobal.toml"
     with open(constants.AUTH_KEY, "r") as f:
         auth_key = f.readline().rstrip()
-    api_url = os.getenv("SFKIT_API_URL", "").replace("https", "wss") + "/ice"
+
+    url = urlparse(constants.SFKIT_API_URL)
+    scheme = "wss" if url.scheme == "https" else "ws"
+    url_path = urljoin(url.path, 'ice')
+    api_url = urlunsplit((scheme, str(url.netloc), url_path, "", ""))
 
     # do not use shell, as this may lead to security
     # vulnerabilities and improper signal handling;

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -230,6 +230,6 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     # 1 sec delay before we start the MPC protocol,
     # such that sfkit-proxy has time to start SOCKS listener;
     # in practice, this happens much quicker within ~100ms
-    sleep(1)
+    sleep(30)
 
     print("sfkit-proxy is running")

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -232,5 +232,4 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     # in practice, this happens much quicker within ~100ms
     sleep(1)
 
-
     print("sfkit-proxy is running")

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -230,6 +230,6 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
     # 1 sec delay before we start the MPC protocol,
     # such that sfkit-proxy has time to start SOCKS listener;
     # in practice, this happens much quicker within ~100ms
-    sleep(30)
+    sleep(1)
 
     print("sfkit-proxy is running")


### PR DESCRIPTION
This PR:
* Sets base port in networking config to `8100` instead of `8000` to avoid conflict with sfkit-proxy's SOCKS port 8000
* Fixes `SFKIT_API_URL` parsing for non-HTTPS URLs (useful in localhost testing)
* Pins https://github.com/hcholab/sfkit-proxy/commit/a422951e720062260fd585aa863743e31c845b51 - going forward it will be much easier using a pinned version, otherwise we end up with "dummy" commits and non-reproducible builds, and it's unclear which commit uses which version of sfkit-proxy
