### PR TITLE
sfkit-proxy security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -s /usr/bin/python python3
 
 FROM go AS sfkit-proxy
 RUN git clone https://github.com/hcholab/sfkit-proxy . && \
-    git checkout 22b24d1 && \
+    git checkout 858e6ca && \
     CGO_ENABLED=0 go build
 
 


### PR DESCRIPTION
Update sfkit-proxy to 858e6ca, which includes:
* QUIC TLS1.3 enforcement
* Masking secrets in logs

Full diff: https://github.com/hcholab/sfkit-proxy/compare/22b24d1...858e6ca