### PR TITLE
[SMC-9] Update prod API URL in WDL workflow

### DIFF
--- a/workflow.wdl
+++ b/workflow.wdl
@@ -5,7 +5,7 @@ workflow sfkit {
     String study_id
     Directory? data
     Int num_cores = 16 # TODO: test with smaller CP0
-    String api_url = "https://sfkit.dsde.broadinstitute.org/api"
+    String api_url = "https://sfkit.dsde-prod.broadinstitute.org/api"
     String docker = "us-central1-docker.pkg.dev/dsp-artifact-registry/sfkit/sfkit"
   }
 


### PR DESCRIPTION
Prod API URL was previously set incorrectly for CLI access.

https://broadworkbench.atlassian.net/browse/SMC-9