### PR TITLE
[SMC-20] Determine ip address based on sfkit proxy instead of setup_configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # hadolint global ignore=DL3006,DL3013,DL3018,DL3041,DL3059
 
 # -------------------- base -------------------- #
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS base
+FROM redhat/ubi9-minimal AS base
 
 
 # -------------------- go -------------------- #
@@ -26,7 +26,7 @@ RUN git clone --depth 1 https://github.com/hcholab/sfgwas . && \
 
 
 # -------------------- sf-relate -------------------- #
-FROM go as sf-relate
+FROM go AS sf-relate
 
 RUN git clone https://github.com/froelich/sf-relate . && \
     git checkout 9d1a076 && \

--- a/sfkit/auth/setup_networking.py
+++ b/sfkit/auth/setup_networking.py
@@ -17,9 +17,8 @@ def setup_networking(ports_str: str = "", ip_address: str = "") -> None:
     )
 
     authenticate_user()
-    doc_ref_dict = get_doc_ref_dict()
-    username = get_username()
-    role: int = doc_ref_dict["participants"].index(username)
+    doc_ref_dict: dict = get_doc_ref_dict()
+    role: int = doc_ref_dict["participants"].index(get_username())
 
     if not ip_address:
         if constants.SFKIT_PROXY_ON:

--- a/sfkit/auth/setup_networking.py
+++ b/sfkit/auth/setup_networking.py
@@ -3,6 +3,7 @@ import socket
 from requests import get
 
 from sfkit.api import get_doc_ref_dict, get_username, update_firestore
+from sfkit.utils import constants
 from sfkit.utils.helper_functions import authenticate_user
 
 MAX_PARTICIPANTS = 10
@@ -16,11 +17,12 @@ def setup_networking(ports_str: str = "", ip_address: str = "") -> None:
     )
 
     authenticate_user()
-    doc_ref_dict: dict = get_doc_ref_dict()
-    role: int = doc_ref_dict["participants"].index(get_username())
+    doc_ref_dict = get_doc_ref_dict()
+    username = get_username()
+    role: int = doc_ref_dict["participants"].index(username)
 
     if not ip_address:
-        if doc_ref_dict["setup_configuration"] == "website":
+        if constants.SFKIT_PROXY_ON:
             ip_address = socket.gethostbyname(socket.gethostname())  # internal ip address
             print("Using internal ip address:", ip_address)
         else:

--- a/tests/auth/test_setup_networking.py
+++ b/tests/auth/test_setup_networking.py
@@ -8,7 +8,6 @@ def test_setup_networking(mocker):
         "sfkit.auth.setup_networking.get_doc_ref_dict",
         return_value={
             "participants": ["a@a.com", "b@b.com"],
-            "setup_configuration": "website",
             "study_type": "SF-RELATE",
         },
     )
@@ -31,7 +30,6 @@ def test_setup_networking(mocker):
         "sfkit.auth.setup_networking.get_doc_ref_dict",
         return_value={
             "participants": ["a@a.com", "b@b.com"],
-            "setup_configuration": "user",
             "study_type": "SF-RELATE",
         },
     )


### PR DESCRIPTION
This is a preparatory PR that switches sfkit CLI away from relying on study-wide `setup_configuration` parameter, which will be deprecated if favor of per-participant configuration, as part of work to streamline workflow submission UX in [SMC-20](https://broadworkbench.atlassian.net/browse/SMC-20).

More generally, `setup_configuration` parameter controlled whether a study was created in "website" or "user" mode, meaning whether the VMs would be created automatically by sfkit portal ("website") or manually ("user"). This parameter was more relevant to pre-Terra sfkit deployment, but even for that we're switching the UX such that each participant can decide if they want the VM to be auto- or manually provisioned.

In the context of sfkit CLI, `setup_configuration` was used to determine how we detect the IP address of the participant. However, this is more accurately represented by the use of `SFKIT_PROXY_ON` environment variable: when it's `true` (such as on Terra), we use a VM's internal IP address, while when it's `false`, we try to find the external address.

We also fix base URI for RedHat base image, since the official RHEL registry seems to be down (the Docker Hub image is also official, and identical).

I've tested that the image still works in Terra dev.

https://broadworkbench.atlassian.net/browse/SMC-20