### PR TITLE
[SMC-25] Customize env vars and libs for sfkit CLI in Terra notebooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,12 @@ ENV OPENSSL_FORCE_FIPS_MODE=1 \
     SFKIT_DIR="/sfkit/.sfkit" \
     SFKIT_PROXY_ON=TRUE
 
-COPY --from=base        --chown=nonroot /usr/lib64/libc.so.6 /usr/lib64/libssl.so.3 ./lib/
+COPY --from=base        --chown=nonroot \
+    /usr/lib64/ld-linux-x86-64.so.2 \
+    /usr/lib64/libc.so.6 \
+    /usr/lib64/libssl.so.3 \
+    ./lib/
+
 COPY --from=plink2      --chown=nonroot /build/plink2   ./
 COPY --from=secure-gwas --chown=nonroot /build          ./secure-gwas/
 COPY --from=sfgwas      --chown=nonroot /build          ./sfgwas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ ENV OPENSSL_FORCE_FIPS_MODE=1 \
     SFKIT_DIR="/sfkit/.sfkit" \
     SFKIT_PROXY_ON=TRUE
 
-COPY --from=base        --chown=nonroot /usr/lib64/libc.so.6 /usr/lib64/libssl.so.3 ./
+COPY --from=base        --chown=nonroot /usr/lib64/libc.so.6 /usr/lib64/libssl.so.3 ./lib/
 COPY --from=plink2      --chown=nonroot /build/plink2   ./
 COPY --from=secure-gwas --chown=nonroot /build          ./secure-gwas/
 COPY --from=sfgwas      --chown=nonroot /build          ./sfgwas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ COPY --from=base        --chown=nonroot \
     /lib64/ld-linux-x86-64.so.2 \
     /lib64/libc.so.6 \
     /lib64/libcrypto.so.3 \
+    /lib64/libpthread.so.0 \
     /lib64/libssl.so.3 \
     /lib64/libstdc++.so.6 \
     ./lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,11 +140,11 @@ ENV OPENSSL_FORCE_FIPS_MODE=1 \
     SFKIT_PROXY_ON=TRUE
 
 COPY --from=base        --chown=nonroot \
-    /usr/lib64/ld-linux-x86-64.so.2 \
-    /usr/lib64/libc.so.6 \
-    /usr/lib64/libcrypto.so.3 \
-    /usr/lib64/libresolv.so.2 \
-    /usr/lib64/libssl.so.3 \
+    /lib64/ld-linux-x86-64.so.2 \
+    /lib64/libc.so.6 \
+    /lib64/libcrypto.so.3 \
+    /lib64/libssl.so.3 \
+    /lib64/libstdc++.so.6 \
     ./lib/
 
 COPY --from=plink2      --chown=nonroot /build/plink2   ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,7 @@ ENV OPENSSL_FORCE_FIPS_MODE=1 \
     SFKIT_DIR="/sfkit/.sfkit" \
     SFKIT_PROXY_ON=TRUE
 
+COPY --from=base        --chown=nonroot /usr/lib64/libc.so.6 /usr/lib64/libssl.so.3 ./
 COPY --from=plink2      --chown=nonroot /build/plink2   ./
 COPY --from=secure-gwas --chown=nonroot /build          ./secure-gwas/
 COPY --from=sfgwas      --chown=nonroot /build          ./sfgwas/

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,8 @@ ENV OPENSSL_FORCE_FIPS_MODE=1 \
 COPY --from=base        --chown=nonroot \
     /usr/lib64/ld-linux-x86-64.so.2 \
     /usr/lib64/libc.so.6 \
+    /usr/lib64/libcrypto.so.3 \
+    /usr/lib64/libresolv.so.2 \
     /usr/lib64/libssl.so.3 \
     ./lib/
 

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ cd sfkit
 python3 -m pip install -U ./sfkit*.whl
 rm ./sfkit*.whl
 mkdir -p ~/.local/bin/ && mv plink2 sfkit-proxy ~/.local/bin/
-mkdir -p ~/.local/lib/ && mv lib*.so.* ~/.local/lib/
+mkdir -p ~/.local/lib/ && mv lib/* ~/.local/lib/
 mkdir -p ~/.local/sfgwas && mv sfgwas ~/.local/
 mkdir -p ~/.local/sf-relate && mv sf-relate ~/.local/
 mkdir -p ~/.local/secure-gwas && mv secure-gwas ~/.local/

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,8 @@ echo Installing sfkit...
 cd sfkit
 python3 -m pip install -U ./sfkit*.whl
 rm ./sfkit*.whl
-mkdir -p ~/.local/bin/ && mv plink2 ~/.local/bin/ && mv sfkit-proxy ~/.local/bin/
+mkdir -p ~/.local/bin/ && mv plink2 sfkit-proxy ~/.local/bin/
+mkdir -p ~/.local/lib/ && mv lib*.so.* ~/.local/lib/
 mkdir -p ~/.local/sfgwas && mv sfgwas ~/.local/
 mkdir -p ~/.local/sf-relate && mv sf-relate ~/.local/
 mkdir -p ~/.local/secure-gwas && mv secure-gwas ~/.local/

--- a/install.sh
+++ b/install.sh
@@ -50,13 +50,19 @@ echo
 
 echo Installing sfkit...
 cd sfkit
-python3 -m pip install -U ./sfkit*.whl
+python3 -m pip install -U patchelf ./sfkit*.whl
 rm ./sfkit*.whl
 mkdir -p ~/.local/bin/ && mv plink2 sfkit-proxy ~/.local/bin/
 mkdir -p ~/.local/lib/ && mv lib/* ~/.local/lib/
 mkdir -p ~/.local/sfgwas && mv sfgwas ~/.local/
 mkdir -p ~/.local/sf-relate && mv sf-relate ~/.local/
 mkdir -p ~/.local/secure-gwas && mv secure-gwas ~/.local/
+echo
+
+echo Patching sfkit binaries...
+for p in ~/.local/bin/sfkit-proxy ~/.local/sfgwas/sfgwas ~/.local/sf-relate/sf-relate ~/.local/secure-gwas/code/bin/* ; do
+  patchelf --set-interpreter ~/.local/lib/ld-linux-x86-64.so.2 "$p"
+done
 echo
 
 if ! type sfkit &>/dev/null || ! echo "$PATH" | grep -q "/.local/bin" ; then

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -5,8 +5,10 @@ import shutil
 def is_installed(binary: str) -> bool:
     return shutil.which(binary) is not None
 
-
-SFKIT_API_URL = os.environ.get("SFKIT_API_URL", "https://sfkit-website-bhj5a4wkqa-uc.a.run.app/api")
+TERRA_DEPLOYMENT_ENV = os.environ.get("TERRA_DEPLOYMENT_ENV")
+SFKIT_API_URL = os.environ.get("SFKIT_API_URL",
+    f"https://sfkit.dsde-{TERRA_DEPLOYMENT_ENV}.broadinstitute.org/api" if TERRA_DEPLOYMENT_ENV
+    else "https://sfkit-website-bhj5a4wkqa-uc.a.run.app/api")
 METADATA_VM_IDENTITY_URL = (
     "http://metadata.google.internal/computeMetadata/v1/"
     "instance/service-accounts/default/identity?"
@@ -17,12 +19,15 @@ SFKIT_DIR = os.environ.get("SFKIT_DIR", os.path.join(os.path.expanduser("~"), ".
 AUTH_FILE = os.path.join(SFKIT_DIR, "auth.txt")
 AUTH_KEY = os.path.join(SFKIT_DIR, "auth_key.txt")
 IS_DOCKER = os.path.exists("/.dockerenv")
-IS_INSTALLED_VIA_SCRIPT = is_installed("sfgwas") and is_installed("plink2") and is_installed("GwasClient")
+IS_INSTALLED_VIA_SCRIPT = (is_installed("sfgwas") and is_installed("plink2") and is_installed("GwasClient")) or TERRA_DEPLOYMENT_ENV
 EXECUTABLES_PREFIX = os.path.expanduser("~") + "/.local/" if IS_INSTALLED_VIA_SCRIPT else ""
+os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib" if IS_INSTALLED_VIA_SCRIPT else ""
+
 SFKIT_PREFIX = "sfkit: "
 OUT_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "out")
 ENCRYPTED_DATA_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "encrypted_data")
-SFKIT_PROXY_ON: bool = os.getenv("SFKIT_PROXY_ON", "false").lower() == "true"
+SFKIT_PROXY_ON: bool = os.getenv("SFKIT_PROXY_ON",
+    "true" if TERRA_DEPLOYMENT_ENV else "false").lower() == "true"
 
 DUMMY_KEY_01 = b"\x97\xa9\xdf\x59\x51\xbc\x43\x5b\x84\x21\x42\x00\x41\xd6\x44\xf5\xa0\xd1\x14\x59\x45\x74\x04\x8f\x56\x10\x59\xf6\xfa\x75\x53\x95"
 DUMMY_KEY_02 = b"\x71\x63\xec\xc9\xbd\x57\xbb\xbf\x28\x61\xec\x09\x7a\x43\x80\x1e\xd5\xac\xcd\xa2\x6e\x39\x85\xdb\x7c\x3e\x10\x19\x9e\xa8\x7b\x46"

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -21,8 +21,8 @@ AUTH_KEY = os.path.join(SFKIT_DIR, "auth_key.txt")
 IS_DOCKER = os.path.exists("/.dockerenv")
 IS_INSTALLED_VIA_SCRIPT = (is_installed("sfgwas") and is_installed("plink2") and is_installed("GwasClient")) or TERRA_DEPLOYMENT_ENV
 EXECUTABLES_PREFIX = os.path.expanduser("~") + "/.local/" if IS_INSTALLED_VIA_SCRIPT else ""
-if os.environ.get("LD_LIBRARY_PATH"):
-    os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib" if IS_INSTALLED_VIA_SCRIPT else ""
+if IS_INSTALLED_VIA_SCRIPT and os.environ.get("LD_LIBRARY_PATH"):
+    os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib"
 
 SFKIT_PREFIX = "sfkit: "
 OUT_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "out")

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -21,7 +21,8 @@ AUTH_KEY = os.path.join(SFKIT_DIR, "auth_key.txt")
 IS_DOCKER = os.path.exists("/.dockerenv")
 IS_INSTALLED_VIA_SCRIPT = (is_installed("sfgwas") and is_installed("plink2") and is_installed("GwasClient")) or TERRA_DEPLOYMENT_ENV
 EXECUTABLES_PREFIX = os.path.expanduser("~") + "/.local/" if IS_INSTALLED_VIA_SCRIPT else ""
-os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib" if IS_INSTALLED_VIA_SCRIPT else ""
+if os.environ.get("LD_LIBRARY_PATH"):
+    os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib" if IS_INSTALLED_VIA_SCRIPT else ""
 
 SFKIT_PREFIX = "sfkit: "
 OUT_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "out")

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -21,8 +21,11 @@ AUTH_KEY = os.path.join(SFKIT_DIR, "auth_key.txt")
 IS_DOCKER = os.path.exists("/.dockerenv")
 IS_INSTALLED_VIA_SCRIPT = (is_installed("sfgwas") and is_installed("plink2") and is_installed("GwasClient")) or TERRA_DEPLOYMENT_ENV
 EXECUTABLES_PREFIX = os.path.expanduser("~") + "/.local/" if IS_INSTALLED_VIA_SCRIPT else ""
-if IS_INSTALLED_VIA_SCRIPT and os.environ.get("LD_LIBRARY_PATH"):
-    os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib"
+if IS_INSTALLED_VIA_SCRIPT:
+    if os.environ.get("LD_LIBRARY_PATH"):
+        os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib"
+    if os.environ.get("PATH"):
+        os.environ["PATH"] += f":{EXECUTABLES_PREFIX}/secure-gwas/code/bin:{EXECUTABLES_PREFIX}/sfgwas:{EXECUTABLES_PREFIX}/sf-relate"
 
 SFKIT_PREFIX = "sfkit: "
 OUT_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "out")


### PR DESCRIPTION
This PR customizes certain environment variables and adds a few missing dynamic libraries to sfkit CLI packaged for use in Terra notebooks. This simplifies setup on user side, and ensures sfkit CLI actually works inside this environment.

