### PR TITLE
[SMC-26] Update sfkit CLI to support configurable SOCKS port in sfkit-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM go AS sfkit-proxy
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 RUN git clone https://github.com/hcholab/sfkit-proxy . && \
-    git checkout 131e791 && \
+    git checkout fea99f1 && \
     go build && \
     # ensure FIPS is enabled, fail if not
     go get github.com/acardace/fips-detect && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM go AS sfkit-proxy
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 RUN git clone https://github.com/hcholab/sfkit-proxy . && \
-    git checkout 3695077 && \
+    git checkout 131e791 && \
     go build && \
     # ensure FIPS is enabled, fail if not
     go get github.com/acardace/fips-detect && \

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -42,4 +42,4 @@ SAFE_DATA_PATH = os.path.join(os.path.realpath(SAFE_DATA_PATH), "")
 
 ENV = os.environ.copy()
 if SFKIT_PROXY_ON:
-    ENV["ALL_PROXY"] = "socks5://localhost:8000"
+    ENV["ALL_PROXY"] = "socks5://localhost:" +  os.environ.get("SFKIT_PROXY_PORT", "7080")

--- a/sfkit/utils/constants.py
+++ b/sfkit/utils/constants.py
@@ -23,9 +23,9 @@ IS_INSTALLED_VIA_SCRIPT = (is_installed("sfgwas") and is_installed("plink2") and
 EXECUTABLES_PREFIX = os.path.expanduser("~") + "/.local/" if IS_INSTALLED_VIA_SCRIPT else ""
 if IS_INSTALLED_VIA_SCRIPT:
     if os.environ.get("LD_LIBRARY_PATH"):
-        os.environ["LD_LIBRARY_PATH"] += ":" + os.path.expanduser("~") + "/.local/lib"
+        os.environ["LD_LIBRARY_PATH"] += f":{EXECUTABLES_PREFIX}lib"
     if os.environ.get("PATH"):
-        os.environ["PATH"] += f":{EXECUTABLES_PREFIX}/secure-gwas/code/bin:{EXECUTABLES_PREFIX}/sfgwas:{EXECUTABLES_PREFIX}/sf-relate"
+        os.environ["PATH"] += f":{EXECUTABLES_PREFIX}bin:{EXECUTABLES_PREFIX}sfgwas:{EXECUTABLES_PREFIX}sf-relate:{EXECUTABLES_PREFIX}secure-gwas/code/bin"
 
 SFKIT_PREFIX = "sfkit: "
 OUT_FOLDER = os.path.join(os.environ.get("SFKIT_DIR", ""), "out")

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -225,6 +225,8 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
         role,
         "-mpc",
         config_file_path,
+        "-socks",
+        os.environ["ALL_PROXY"],
     ]
     if not auth_key.startswith("study_id:"):
         command.extend(["-auth-key", auth_key])

--- a/sfkit/utils/sfgwas_helper_functions.py
+++ b/sfkit/utils/sfgwas_helper_functions.py
@@ -226,7 +226,7 @@ def boot_sfkit_proxy(role: str, protocol: str) -> None:
         "-mpc",
         config_file_path,
         "-socks",
-        os.environ["ALL_PROXY"],
+        constants.ENV["ALL_PROXY"],
     ]
     if not auth_key.startswith("study_id:"):
         command.extend(["-auth-key", auth_key])


### PR DESCRIPTION
This PR updates sfkit-proxy to the version that runs local SOCKS proxy on another localhost port, instead of :8000. The port value can now be configured via `SFKIT_PROXY_PORT` variable, and defaults to `7080`. Additionally, it no longer listens on all network interfaces, which improves security. This change was triggered by a port conflict in Terra notebooks.

It also fixes a couple PATHs variables that were not set correctly in https://github.com/hcholab/sfkit/pull/50

Diff between the associated commits in sfkit-proxy: https://github.com/hcholab/sfkit-proxy/compare/3695077..fea99f1

 https://broadworkbench.atlassian.net/browse/SMC-26